### PR TITLE
Bugfix: Update plugin version to fix bug about shadow jar

### DIFF
--- a/cli-lanterna/build.gradle
+++ b/cli-lanterna/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.4'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:5.2.0'
     }
 }
 

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.4'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:5.2.0'
     }
 }
 

--- a/gui/build.gradle
+++ b/gui/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
         classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.11.0'
         classpath 'org.gradle.api.plugins:gradle-izpack-plugin:0.2.3'
-        classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.4'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:5.2.0'
         classpath 'com.github.cr0:gradle-macappbundle-plugin:3.1.0'
         classpath 'org.kordamp.gradle:stats-gradle-plugin:0.2.2'
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'


### PR DESCRIPTION
Hello

This commit fixes a bug regarding the creation of shadow jar.

This project uses a gradle plugin to generate the shadow jar of three sub-projects. However, the version 2.0.4 of this plugin has a bug regarding the creation of the shadow jar.

Specifically, the name of the generated shadow jars does not include the `-all.jar` suffix. As a result, the generated shadow jars conflict with those jars generated by the naive `jar` task. So, there might be a race condition depending on the order in which gradle executes tasks `jar` and `shadowJar`.

Later versions of this plugin fixes this problem (See [here](https://imperceptiblethoughts.com/shadow/changes/)). Therefore this pull request update the version of the plugin so that the name of the generated shadow jars ends with the `-all.jar` suffix.