### PR TITLE
Introduce persister that uses a directory structure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM jlesage/baseimage-gui:alpine-3.10-glibc
 ARG DOCKER_IMAGE_VERSION=unknown
 
 # JDK version
-ARG JDK=9
+ARG JDK=11
 
 # Important directories
 ARG TMP_DIR=/muwire-tmp

--- a/cli-lanterna/src/main/groovy/com/muwire/clilanterna/FilesView.groovy
+++ b/cli-lanterna/src/main/groovy/com/muwire/clilanterna/FilesView.groovy
@@ -21,7 +21,6 @@ import com.muwire.core.filecert.UICreateCertificateEvent
 import com.muwire.core.files.DirectoryUnsharedEvent
 import com.muwire.core.files.FileSharedEvent
 import com.muwire.core.files.FileUnsharedEvent
-import com.muwire.core.files.UIPersistFilesEvent
 
 class FilesView extends BasicWindow {
     private final FilesModel model
@@ -84,7 +83,6 @@ class FilesView extends BasicWindow {
         
         Button unshareButton = new Button("Unshare", {
             core.eventBus.publish(new FileUnsharedEvent(unsharedFile : sf))
-            core.eventBus.publish(new UIPersistFilesEvent())
             MessageDialog.showMessageDialog(textGUI, "File Unshared", "Unshared "+sf.getFile().getName(), MessageDialogButton.OK)
         } )
         Button addCommentButton = new Button("Add Comment", {

--- a/core/src/main/groovy/com/muwire/core/Core.groovy
+++ b/core/src/main/groovy/com/muwire/core/Core.groovy
@@ -264,6 +264,7 @@ public class Core {
         log.info "initializing folder persistence service"
         persisterFolderService = new PersisterFolderService(new File(home, "files"), eventBus)
         eventBus.register(PersisterDoneEvent.class, persisterFolderService)
+        eventBus.register(FileLoadedEvent.class, persisterFolderService)
         eventBus.register(FileHashedEvent.class, persisterFolderService)
         eventBus.register(FileUnsharedEvent.class, persisterFolderService)
 

--- a/core/src/main/groovy/com/muwire/core/Core.groovy
+++ b/core/src/main/groovy/com/muwire/core/Core.groovy
@@ -264,6 +264,7 @@ public class Core {
         log.info "initializing folder persistence service"
         persisterFolderService = new PersisterFolderService(new File(home, "files"), eventBus)
         eventBus.register(PersisterDoneEvent.class, persisterFolderService)
+        eventBus.register(FileDownloadedEvent.class, persisterFolderService)
         eventBus.register(FileLoadedEvent.class, persisterFolderService)
         eventBus.register(FileHashedEvent.class, persisterFolderService)
         eventBus.register(FileUnsharedEvent.class, persisterFolderService)

--- a/core/src/main/groovy/com/muwire/core/Core.groovy
+++ b/core/src/main/groovy/com/muwire/core/Core.groovy
@@ -43,7 +43,7 @@ import com.muwire.core.files.HasherService
 import com.muwire.core.files.PersisterService
 import com.muwire.core.files.SideCarFileEvent
 import com.muwire.core.files.UICommentEvent
-import com.muwire.core.files.UIPersistFilesEvent
+
 import com.muwire.core.files.AllFilesLoadedEvent
 import com.muwire.core.files.DirectoryUnsharedEvent
 import com.muwire.core.files.DirectoryWatchedEvent
@@ -264,7 +264,6 @@ public class Core {
         log.info "initializing folder persistence service"
         persisterFolderService = new PersisterFolderService(new File(home, "files"), eventBus)
         eventBus.register(PersisterDoneEvent.class, persisterFolderService)
-        eventBus.register(UIPersistFilesEvent.class, persisterFolderService)
         eventBus.register(FileHashedEvent.class, persisterFolderService)
         eventBus.register(FileUnsharedEvent.class, persisterFolderService)
 

--- a/core/src/main/groovy/com/muwire/core/Core.groovy
+++ b/core/src/main/groovy/com/muwire/core/Core.groovy
@@ -1,5 +1,6 @@
 package com.muwire.core
 
+import com.muwire.core.files.PersisterDoneEvent
 import com.muwire.core.files.PersisterFolderService
 
 import java.nio.charset.StandardCharsets
@@ -262,7 +263,7 @@ public class Core {
 
         log.info "initializing folder persistence service"
         persisterFolderService = new PersisterFolderService(new File(home, "files"), eventBus)
-        eventBus.register(UILoadedEvent.class, persisterFolderService)
+        eventBus.register(PersisterDoneEvent.class, persisterFolderService)
         eventBus.register(UIPersistFilesEvent.class, persisterFolderService)
         eventBus.register(FileHashedEvent.class, persisterFolderService)
         eventBus.register(FileUnsharedEvent.class, persisterFolderService)

--- a/core/src/main/groovy/com/muwire/core/Core.groovy
+++ b/core/src/main/groovy/com/muwire/core/Core.groovy
@@ -262,7 +262,7 @@ public class Core {
         eventBus.register(UILoadedEvent.class, persisterService)
 
         log.info "initializing folder persistence service"
-        persisterFolderService = new PersisterFolderService(new File(home, "files"), eventBus)
+        persisterFolderService = new PersisterFolderService(this, new File(home, "files"), eventBus)
         eventBus.register(PersisterDoneEvent.class, persisterFolderService)
         eventBus.register(FileDownloadedEvent.class, persisterFolderService)
         eventBus.register(FileLoadedEvent.class, persisterFolderService)

--- a/core/src/main/groovy/com/muwire/core/connection/Connection.groovy
+++ b/core/src/main/groovy/com/muwire/core/connection/Connection.groovy
@@ -88,11 +88,11 @@ abstract class Connection implements Closeable {
             log.log(Level.WARNING, "$name already closed", new Exception() )
             return
         }
-        log.info("closing $name")
+        log.fine("closing $name")
         reader.interrupt()
         writer.interrupt()
         endpoint.close()
-        log.info("closed $name")
+        log.fine("closed $name")
         eventBus.publish(new DisconnectionEvent(destination: endpoint.destination))
     }
 

--- a/core/src/main/groovy/com/muwire/core/connection/Connection.groovy
+++ b/core/src/main/groovy/com/muwire/core/connection/Connection.groovy
@@ -88,11 +88,11 @@ abstract class Connection implements Closeable {
             log.log(Level.WARNING, "$name already closed", new Exception() )
             return
         }
-        log.fine("closing $name")
+        log.info("closing $name")
         reader.interrupt()
         writer.interrupt()
         endpoint.close()
-        log.fine("closed $name")
+        log.info("closed $name")
         eventBus.publish(new DisconnectionEvent(destination: endpoint.destination))
     }
 

--- a/core/src/main/groovy/com/muwire/core/files/BasePersisterService.groovy
+++ b/core/src/main/groovy/com/muwire/core/files/BasePersisterService.groovy
@@ -53,7 +53,7 @@ abstract class BasePersisterService extends Service{
             Set<Destination> sourceSet = sources.stream().map({ d -> new Destination(d.toString())}).collect Collectors.toSet()
             DownloadedFile df = new DownloadedFile(file, ih, pieceSize, sourceSet)
             df.setComment(json.comment)
-            return new FileLoadedEvent(loadedFile : df, source : "PersisterService")
+            return new FileLoadedEvent(loadedFile : df)
         }
 
 
@@ -71,7 +71,7 @@ abstract class BasePersisterService extends Service{
                 sf.hit(searcher, timestamp, query)
             }
         }
-        return new FileLoadedEvent(loadedFile: sf, source : "PersisterService")
+        return new FileLoadedEvent(loadedFile: sf)
 
     }
 

--- a/core/src/main/groovy/com/muwire/core/files/BasePersisterService.groovy
+++ b/core/src/main/groovy/com/muwire/core/files/BasePersisterService.groovy
@@ -1,0 +1,109 @@
+package com.muwire.core.files
+
+import com.muwire.core.DownloadedFile
+import com.muwire.core.InfoHash
+import com.muwire.core.Persona
+import com.muwire.core.Service
+import com.muwire.core.SharedFile
+import com.muwire.core.util.DataUtil
+import net.i2p.data.Base64
+import net.i2p.data.Destination
+
+import java.util.stream.Collectors
+
+abstract class BasePersisterService extends Service{
+
+    protected static FileLoadedEvent fromJson(def json) {
+        if (json.file == null || json.length == null || json.infoHash == null || json.hashList == null)
+            throw new IllegalArgumentException()
+        if (!(json.hashList instanceof List))
+            throw new IllegalArgumentException()
+
+        def file = new File(DataUtil.readi18nString(Base64.decode(json.file)))
+        file = file.getCanonicalFile()
+        if (!file.exists() || file.isDirectory())
+            return null
+        long length = Long.valueOf(json.length)
+        if (length != file.length())
+            return null
+
+        List hashList = (List) json.hashList
+        ByteArrayOutputStream baos = new ByteArrayOutputStream()
+        hashList.each {
+            byte [] hash = Base64.decode it.toString()
+            if (hash == null)
+                throw new IllegalArgumentException()
+            baos.write hash
+        }
+        byte[] hashListBytes = baos.toByteArray()
+
+        InfoHash ih = InfoHash.fromHashList(hashListBytes)
+        byte [] root = Base64.decode(json.infoHash.toString())
+        if (root == null)
+            throw new IllegalArgumentException()
+        if (!Arrays.equals(root, ih.getRoot()))
+            return null
+
+        int pieceSize = 0
+        if (json.pieceSize != null)
+            pieceSize = json.pieceSize
+
+        if (json.sources != null) {
+            List sources = (List)json.sources
+            Set<Destination> sourceSet = sources.stream().map({ d -> new Destination(d.toString())}).collect Collectors.toSet()
+            DownloadedFile df = new DownloadedFile(file, ih, pieceSize, sourceSet)
+            df.setComment(json.comment)
+            return new FileLoadedEvent(loadedFile : df, sourceClass : this.class)
+        }
+
+
+        SharedFile sf = new SharedFile(file, ih, pieceSize)
+        sf.setComment(json.comment)
+        if (json.downloaders != null)
+            sf.getDownloaders().addAll(json.downloaders)
+        if (json.searchers != null) {
+            json.searchers.each {
+                Persona searcher = null
+                if (it.searcher != null)
+                    searcher = new Persona(new ByteArrayInputStream(Base64.decode(it.searcher)))
+                long timestamp = it.timestamp
+                String query = it.query
+                sf.hit(searcher, timestamp, query)
+            }
+        }
+        return new FileLoadedEvent(loadedFile: sf)
+
+    }
+
+    protected static toJson(SharedFile sf) {
+        def json = [:]
+        json.file = sf.getB64EncodedFileName()
+        json.length = sf.getCachedLength()
+        InfoHash ih = sf.getInfoHash()
+        json.infoHash = sf.getB64EncodedHashRoot()
+        json.pieceSize = sf.getPieceSize()
+        json.hashList = sf.getB64EncodedHashList()
+        json.comment = sf.getComment()
+        json.hits = sf.getHits()
+        json.downloaders = sf.getDownloaders()
+
+        if (!sf.searches.isEmpty()) {
+            Set searchers = new HashSet<>()
+            sf.searches.each {
+                def search = [:]
+                if (it.searcher != null)
+                    search.searcher = it.searcher.toBase64()
+                search.timestamp = it.timestamp
+                search.query = it.query
+                searchers.add(search)
+            }
+            json.searchers = searchers
+        }
+
+        if (sf instanceof DownloadedFile) {
+            json.sources = sf.sources.stream().map( {d -> d.toBase64()}).collect(Collectors.toList())
+        }
+
+        json
+    }
+}

--- a/core/src/main/groovy/com/muwire/core/files/BasePersisterService.groovy
+++ b/core/src/main/groovy/com/muwire/core/files/BasePersisterService.groovy
@@ -53,7 +53,7 @@ abstract class BasePersisterService extends Service{
             Set<Destination> sourceSet = sources.stream().map({ d -> new Destination(d.toString())}).collect Collectors.toSet()
             DownloadedFile df = new DownloadedFile(file, ih, pieceSize, sourceSet)
             df.setComment(json.comment)
-            return new FileLoadedEvent(loadedFile : df, sourceClass : this.class)
+            return new FileLoadedEvent(loadedFile : df, source : "PersisterService")
         }
 
 
@@ -71,7 +71,7 @@ abstract class BasePersisterService extends Service{
                 sf.hit(searcher, timestamp, query)
             }
         }
-        return new FileLoadedEvent(loadedFile: sf, sourceClass: this.class)
+        return new FileLoadedEvent(loadedFile: sf, source : "PersisterService")
 
     }
 

--- a/core/src/main/groovy/com/muwire/core/files/BasePersisterService.groovy
+++ b/core/src/main/groovy/com/muwire/core/files/BasePersisterService.groovy
@@ -71,7 +71,7 @@ abstract class BasePersisterService extends Service{
                 sf.hit(searcher, timestamp, query)
             }
         }
-        return new FileLoadedEvent(loadedFile: sf)
+        return new FileLoadedEvent(loadedFile: sf, sourceClass: this.class)
 
     }
 

--- a/core/src/main/groovy/com/muwire/core/files/FileLoadedEvent.groovy
+++ b/core/src/main/groovy/com/muwire/core/files/FileLoadedEvent.groovy
@@ -6,4 +6,5 @@ import com.muwire.core.SharedFile
 class FileLoadedEvent extends Event {
 
     SharedFile loadedFile
+    Class sourceClass
 }

--- a/core/src/main/groovy/com/muwire/core/files/FileLoadedEvent.groovy
+++ b/core/src/main/groovy/com/muwire/core/files/FileLoadedEvent.groovy
@@ -6,5 +6,5 @@ import com.muwire.core.SharedFile
 class FileLoadedEvent extends Event {
 
     SharedFile loadedFile
-    Class sourceClass
+    String source
 }

--- a/core/src/main/groovy/com/muwire/core/files/PersisterDoneEvent.groovy
+++ b/core/src/main/groovy/com/muwire/core/files/PersisterDoneEvent.groovy
@@ -1,0 +1,12 @@
+package com.muwire.core.files
+
+import com.muwire.core.Event
+
+/**
+ * Should be triggered by the old PersisterService
+ * once it has finished reading the old file
+ *
+ * @see PersisterService
+ */
+class PersisterDoneEvent extends Event{
+}

--- a/core/src/main/groovy/com/muwire/core/files/PersisterFolderService.groovy
+++ b/core/src/main/groovy/com/muwire/core/files/PersisterFolderService.groovy
@@ -19,6 +19,8 @@ import java.util.logging.Level
  *
  * The absolute path's 32bit hash to the shared file is used
  * to build the directory and filename.
+ *
+ * This persister only starts working once the old persister has finished loading
  * @see PersisterFolderService#getJsonPath
  */
 @Log
@@ -46,8 +48,8 @@ class PersisterFolderService extends BasePersisterService {
         persisterExecutor.shutdown()
     }
 
-    void onUILoadedEvent(UILoadedEvent e) {
-        timer.schedule({ load() } as TimerTask, 1)
+    void onPersisterDoneEvent(PersisterDoneEvent persisterDoneEvent) {
+        load()
     }
 
     void onUIPersistFilesEvent(UIPersistFilesEvent e) {

--- a/core/src/main/groovy/com/muwire/core/files/PersisterFolderService.groovy
+++ b/core/src/main/groovy/com/muwire/core/files/PersisterFolderService.groovy
@@ -52,10 +52,6 @@ class PersisterFolderService extends BasePersisterService {
         load()
     }
 
-    void onUIPersistFilesEvent(UIPersistFilesEvent e) {
-        persistFiles()
-    }
-
     void onFileHashedEvent(FileHashedEvent hashedEvent) {
         persistFile(hashedEvent.sharedFile)
     }

--- a/core/src/main/groovy/com/muwire/core/files/PersisterFolderService.groovy
+++ b/core/src/main/groovy/com/muwire/core/files/PersisterFolderService.groovy
@@ -28,6 +28,7 @@ class PersisterFolderService extends BasePersisterService {
 
     final static int CUT_LENGTH = 6
 
+    private final Core core;
     final File location
     final EventBus listener
     final int interval
@@ -36,7 +37,8 @@ class PersisterFolderService extends BasePersisterService {
         new Thread(r, "file persister")
     } as ThreadFactory)
 
-    PersisterFolderService(File location, EventBus listener) {
+    PersisterFolderService(Core core, File location, EventBus listener) {
+        this.core = core;
         this.location = location
         this.listener = listener
         this.interval = interval
@@ -58,7 +60,9 @@ class PersisterFolderService extends BasePersisterService {
     }
 
     void onFileDownloadedEvent(FileDownloadedEvent downloadedEvent) {
-        persistFile(downloadedEvent.downloadedFile)
+        if (core.getMuOptions().getShareDownloadedFiles()) {
+            persistFile(downloadedEvent.downloadedFile)
+        }
     }
 
     /**

--- a/core/src/main/groovy/com/muwire/core/files/PersisterFolderService.groovy
+++ b/core/src/main/groovy/com/muwire/core/files/PersisterFolderService.groovy
@@ -68,8 +68,9 @@ class PersisterFolderService extends BasePersisterService {
         }
     }
     void onFileLoadedEvent(FileLoadedEvent loadedEvent) {
-        if(loadedEvent.sourceClass == PersisterService){
-            log.info("Migrating persisted file from PersisterService")
+        if(loadedEvent.source == "PersisterService"){
+            log.info("Migrating persisted file from PersisterService: "
+                    + loadedEvent.loadedFile.file.absolutePath.toString())
             persistFile(loadedEvent.loadedFile)
         }
     }
@@ -124,7 +125,7 @@ class PersisterFolderService extends BasePersisterService {
             def jsonPath = getJsonPath(sf)
 
             def startTime = System.currentTimeMillis()
-            jsonPath.parent.toFile().mkdir()
+            jsonPath.parent.toFile().mkdirs()
             jsonPath.toFile().withPrintWriter { writer ->
                 def json = toJson sf
                 json = JsonOutput.toJson(json)

--- a/core/src/main/groovy/com/muwire/core/files/PersisterFolderService.groovy
+++ b/core/src/main/groovy/com/muwire/core/files/PersisterFolderService.groovy
@@ -95,10 +95,6 @@ class PersisterFolderService extends BasePersisterService {
 
     /**
      * Loads every JSON into memory
-     *
-     * TODO: Decide if this is a good idea
-     *       The more shared files, the more we'll load in memory.
-     *       It might not be necessary
      */
     private void _load() {
         int loaded = 0

--- a/core/src/main/groovy/com/muwire/core/files/PersisterFolderService.groovy
+++ b/core/src/main/groovy/com/muwire/core/files/PersisterFolderService.groovy
@@ -49,6 +49,7 @@ class PersisterFolderService extends BasePersisterService {
     }
 
     void onPersisterDoneEvent(PersisterDoneEvent persisterDoneEvent) {
+        log.info("Old persister done")
         load()
     }
 
@@ -74,6 +75,7 @@ class PersisterFolderService extends BasePersisterService {
     }
 
     void load() {
+        log.fine("Loading...")
         Thread.currentThread().setPriority(Thread.MIN_PRIORITY)
 
         if (location.exists() && location.isDirectory()) {

--- a/core/src/main/groovy/com/muwire/core/files/PersisterFolderService.groovy
+++ b/core/src/main/groovy/com/muwire/core/files/PersisterFolderService.groovy
@@ -1,0 +1,144 @@
+package com.muwire.core.files
+
+import com.muwire.core.*
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+import groovy.util.logging.Log
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.ThreadFactory
+import java.util.logging.Level
+
+/**
+ * A persister that stores information about the files shared using
+ * individual JSON files in directories.
+ *
+ * The absolute path's 32bit hash to the shared file is used
+ * to build the directory and filename.
+ * @see PersisterFolderService#getJsonPath
+ */
+@Log
+class PersisterFolderService extends BasePersisterService {
+
+    final static int CUT_LENGTH = 6
+
+    final File location
+    final EventBus listener
+    final int interval
+    final Timer timer
+    final ExecutorService persisterExecutor = Executors.newSingleThreadExecutor({ r ->
+        new Thread(r, "file persister")
+    } as ThreadFactory)
+
+    PersisterFolderService(File location, EventBus listener) {
+        this.location = location
+        this.listener = listener
+        this.interval = interval
+        timer = new Timer("file-folder persister timer", true)
+    }
+
+    void stop() {
+        timer.cancel()
+        persisterExecutor.shutdown()
+    }
+
+    void onUILoadedEvent(UILoadedEvent e) {
+        timer.schedule({ load() } as TimerTask, 1)
+    }
+
+    void onUIPersistFilesEvent(UIPersistFilesEvent e) {
+        persistFiles()
+    }
+
+    void onFileHashedEvent(FileHashedEvent hashedEvent) {
+        persistFile(hashedEvent.sharedFile)
+    }
+    /**
+     * Get rid of the json of unshared files
+     * @param unsharedEvent
+     */
+    void onFileUnsharedEvent(FileUnsharedEvent unsharedEvent) {
+        def jsonPath = getJsonPath(unsharedEvent.unsharedFile)
+        def jsonFile = jsonPath.toFile()
+        if(jsonFile.isFile()){
+            jsonFile.delete()
+        }
+    }
+    void onFileLoadedEvent(FileLoadedEvent loadedEvent) {
+        if(loadedEvent.sourceClass == PersisterService){
+            log.info("Migrating persisted file from PersisterService")
+            persistFile(loadedEvent.loadedFile)
+        }
+    }
+
+    void load() {
+        Thread.currentThread().setPriority(Thread.MIN_PRIORITY)
+
+        if (location.exists() && location.isDirectory()) {
+            try {
+                _load()
+            }
+            catch (IllegalArgumentException e) {
+                log.log(Level.WARNING, "couldn't load files", e)
+            }
+        } else {
+            location.mkdirs()
+            listener.publish(new AllFilesLoadedEvent())
+        }
+        loaded = true
+    }
+
+    /**
+     * Loads every JSON into memory
+     *
+     * TODO: Decide if this is a good idea
+     *       The more shared files, the more we'll load in memory.
+     *       It might not be necessary
+     */
+    private void _load() {
+        int loaded = 0
+        def slurper = new JsonSlurper()
+        Files.walk(location.toPath())
+                .filter({ it.fileName.endsWith(".json") })
+                .forEach({
+                    def parsed = slurper.parse it.toFile()
+                    def event = fromJson parsed
+                    if (event == null) return
+
+                    log.fine("loaded file $event.loadedFile.file")
+                    listener.publish event
+                    loaded++
+                    if (loaded % 10 == 0)
+                        Thread.sleep(20)
+
+                })
+        listener.publish(new AllFilesLoadedEvent())
+    }
+
+    private void persistFile(SharedFile sf) {
+        persisterExecutor.submit({
+            def jsonPath = getJsonPath(sf)
+
+            def startTime = System.currentTimeMillis()
+            jsonPath.parent.toFile().mkdir()
+            jsonPath.toFile().withPrintWriter { writer ->
+                def json = toJson sf
+                json = JsonOutput.toJson(json)
+                writer.println json
+            }
+            log.fine("Time(ms) to write json: " + (System.currentTimeMillis() - startTime))
+        } as Runnable)
+    }
+    private Path getJsonPath(SharedFile sf){
+        def pathHash = sf.getB64PathHash()
+        return Paths.get(
+                location.getAbsolutePath(),
+                pathHash.substring(0, CUT_LENGTH),
+                pathHash.substring(CUT_LENGTH) + ".json"
+        )
+    }
+}

--- a/core/src/main/groovy/com/muwire/core/files/PersisterFolderService.groovy
+++ b/core/src/main/groovy/com/muwire/core/files/PersisterFolderService.groovy
@@ -56,6 +56,11 @@ class PersisterFolderService extends BasePersisterService {
     void onFileHashedEvent(FileHashedEvent hashedEvent) {
         persistFile(hashedEvent.sharedFile)
     }
+
+    void onFileDownloadedEvent(FileDownloadedEvent downloadedEvent) {
+        persistFile(downloadedEvent.downloadedFile)
+    }
+
     /**
      * Get rid of the json of unshared files
      * @param unsharedEvent

--- a/core/src/main/groovy/com/muwire/core/files/PersisterService.groovy
+++ b/core/src/main/groovy/com/muwire/core/files/PersisterService.groovy
@@ -1,31 +1,18 @@
 package com.muwire.core.files
 
-import java.nio.file.CopyOption
-import java.nio.file.Files
-import java.nio.file.StandardCopyOption
+
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.ThreadFactory
 import java.util.logging.Level
-import java.util.stream.Collectors
 
-import com.muwire.core.DownloadedFile
 import com.muwire.core.EventBus
-import com.muwire.core.InfoHash
-import com.muwire.core.Persona
-import com.muwire.core.Service
-import com.muwire.core.SharedFile
 import com.muwire.core.UILoadedEvent
-import com.muwire.core.util.DataUtil
-
-import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 import groovy.util.logging.Log
-import net.i2p.data.Base64
-import net.i2p.data.Destination
 
 @Log
-class PersisterService extends Service {
+class PersisterService extends BasePersisterService {
 
     final File location
     final EventBus listener
@@ -46,14 +33,11 @@ class PersisterService extends Service {
 
     void stop() {
         timer.cancel()
+        persisterExecutor.shutdown()
     }
 
     void onUILoadedEvent(UILoadedEvent e) {
         timer.schedule({load()} as TimerTask, 1)
-    }
-    
-    void onUIPersistFilesEvent(UIPersistFilesEvent e) {
-        persistFiles()
     }
 
     void load() {
@@ -76,130 +60,17 @@ class PersisterService extends Service {
                         }
                     }
                 }
+                // TODO: should PersisterFolderService be the one doing this?
                 listener.publish(new AllFilesLoadedEvent())
-            } catch (IllegalArgumentException|NumberFormatException e) {
+            } catch (IllegalArgumentException e) {
                 log.log(Level.WARNING, "couldn't load files",e)
             }
         } else {
+            // TODO: should PersisterFolderService be the one doing this?
             listener.publish(new AllFilesLoadedEvent())
         }
-        timer.schedule({persistFiles()} as TimerTask, 1000, interval)
+        // TODO: Get rid of the files.json
         loaded = true
     }
 
-    private static FileLoadedEvent fromJson(def json) {
-        if (json.file == null || json.length == null || json.infoHash == null || json.hashList == null)
-            throw new IllegalArgumentException()
-        if (!(json.hashList instanceof List))
-            throw new IllegalArgumentException()
-
-        def file = new File(DataUtil.readi18nString(Base64.decode(json.file)))
-        file = file.getCanonicalFile()
-        if (!file.exists() || file.isDirectory())
-            return null
-        long length = Long.valueOf(json.length)
-        if (length != file.length())
-            return null
-
-        List hashList = (List) json.hashList
-        ByteArrayOutputStream baos = new ByteArrayOutputStream()
-        hashList.each {
-            byte [] hash = Base64.decode it.toString()
-            if (hash == null)
-                throw new IllegalArgumentException()
-            baos.write hash
-        }
-        byte[] hashListBytes = baos.toByteArray()
-
-        InfoHash ih = InfoHash.fromHashList(hashListBytes)
-        byte [] root = Base64.decode(json.infoHash.toString())
-        if (root == null)
-            throw new IllegalArgumentException()
-        if (!Arrays.equals(root, ih.getRoot()))
-            return null
-
-        int pieceSize = 0
-        if (json.pieceSize != null)
-            pieceSize = json.pieceSize
-
-        if (json.sources != null) {
-            List sources = (List)json.sources
-            Set<Destination> sourceSet = sources.stream().map({d -> new Destination(d.toString())}).collect Collectors.toSet()
-            DownloadedFile df = new DownloadedFile(file, ih, pieceSize, sourceSet)
-            df.setComment(json.comment)
-            return new FileLoadedEvent(loadedFile : df)
-        }
-
-
-        SharedFile sf = new SharedFile(file, ih, pieceSize)
-        sf.setComment(json.comment)
-        if (json.downloaders != null)
-            sf.getDownloaders().addAll(json.downloaders)
-        if (json.searchers != null) {
-            json.searchers.each {
-                Persona searcher = null
-                if (it.searcher != null)
-                    searcher = new Persona(new ByteArrayInputStream(Base64.decode(it.searcher)))
-                long timestamp = it.timestamp
-                String query = it.query
-                sf.hit(searcher, timestamp, query)
-            }
-        }
-        return new FileLoadedEvent(loadedFile: sf)
-
-    }
-
-    private void persistFiles() {
-        persisterExecutor.submit( {
-            def sharedFiles = fileManager.getSharedFiles()
-
-            File tmp = File.createTempFile("muwire-files", "tmp")
-            tmp.deleteOnExit()
-            def startTime = System.currentTimeMillis()
-            tmp.withPrintWriter { writer ->
-                sharedFiles.each { k, v ->
-                    def json = toJson(k,v)
-                    json = JsonOutput.toJson(json)
-                    writer.println json
-                }
-            }
-            log.info("Time(ms) to write tmp files.json: "+ (System.currentTimeMillis() - startTime))
-            startTime = System.currentTimeMillis()
-            Files.copy(tmp.toPath(), location.toPath(), StandardCopyOption.REPLACE_EXISTING)
-            log.info("Time(ms) to copy tmp files.json: "+ (System.currentTimeMillis() - startTime))
-            tmp.delete()
-        } as Runnable)
-    }
-
-    private def toJson(File f, SharedFile sf) {
-        def json = [:]
-        json.file = sf.getB64EncodedFileName()
-        json.length = sf.getCachedLength()
-        InfoHash ih = sf.getInfoHash()
-        json.infoHash = sf.getB64EncodedHashRoot()
-        json.pieceSize = sf.getPieceSize()
-        json.hashList = sf.getB64EncodedHashList()
-        json.comment = sf.getComment()
-        json.hits = sf.getHits()
-        json.downloaders = sf.getDownloaders()
-
-        if (!sf.searches.isEmpty()) {
-            Set searchers = new HashSet<>()
-            sf.searches.each {
-                def search = [:]
-                if (it.searcher != null)
-                    search.searcher = it.searcher.toBase64()
-                search.timestamp = it.timestamp
-                search.query = it.query
-                searchers.add(search)
-            }
-            json.searchers = searchers
-        }
-        
-        if (sf instanceof DownloadedFile) {
-            json.sources = sf.sources.stream().map( {d -> d.toBase64()}).collect(Collectors.toList())
-        }
-
-        json
-    }
 }

--- a/core/src/main/groovy/com/muwire/core/files/PersisterService.groovy
+++ b/core/src/main/groovy/com/muwire/core/files/PersisterService.groovy
@@ -19,9 +19,6 @@ class PersisterService extends BasePersisterService {
     final int interval
     final Timer timer
     final FileManager fileManager
-    final ExecutorService persisterExecutor = Executors.newSingleThreadExecutor({ r -> 
-        new Thread(r, "file persister")
-    } as ThreadFactory)
 
     PersisterService(File location, EventBus listener, int interval, FileManager fileManager) {
         this.location = location
@@ -33,7 +30,6 @@ class PersisterService extends BasePersisterService {
 
     void stop() {
         timer.cancel()
-        persisterExecutor.shutdown()
     }
 
     void onUILoadedEvent(UILoadedEvent e) {

--- a/core/src/main/groovy/com/muwire/core/files/PersisterService.groovy
+++ b/core/src/main/groovy/com/muwire/core/files/PersisterService.groovy
@@ -60,16 +60,17 @@ class PersisterService extends BasePersisterService {
                         }
                     }
                 }
-                // TODO: should PersisterFolderService be the one doing this?
-                listener.publish(new AllFilesLoadedEvent())
+                // Backup the old hashes
+                location.renameTo(
+                        new File(location.absolutePath + ".bak")
+                )
+                listener.publish(new PersisterDoneEvent())
             } catch (IllegalArgumentException e) {
                 log.log(Level.WARNING, "couldn't load files",e)
             }
         } else {
-            // TODO: should PersisterFolderService be the one doing this?
-            listener.publish(new AllFilesLoadedEvent())
+            listener.publish(new PersisterDoneEvent())
         }
-        // TODO: Get rid of the files.json
         loaded = true
     }
 

--- a/core/src/main/groovy/com/muwire/core/files/PersisterService.groovy
+++ b/core/src/main/groovy/com/muwire/core/files/PersisterService.groovy
@@ -49,6 +49,7 @@ class PersisterService extends BasePersisterService {
                         def event = fromJson parsed
                         if (event != null) {
                             log.fine("loaded file $event.loadedFile.file")
+                            event.source = "PersisterService"
                             listener.publish event
                             loaded++
                             if (loaded % 10 == 0)

--- a/core/src/main/groovy/com/muwire/core/files/PersisterService.groovy
+++ b/core/src/main/groovy/com/muwire/core/files/PersisterService.groovy
@@ -155,6 +155,7 @@ class PersisterService extends Service {
 
             File tmp = File.createTempFile("muwire-files", "tmp")
             tmp.deleteOnExit()
+            def startTime = System.currentTimeMillis()
             tmp.withPrintWriter { writer ->
                 sharedFiles.each { k, v ->
                     def json = toJson(k,v)
@@ -162,7 +163,10 @@ class PersisterService extends Service {
                     writer.println json
                 }
             }
+            log.info("Time(ms) to write tmp files.json: "+ (System.currentTimeMillis() - startTime))
+            startTime = System.currentTimeMillis()
             Files.copy(tmp.toPath(), location.toPath(), StandardCopyOption.REPLACE_EXISTING)
+            log.info("Time(ms) to copy tmp files.json: "+ (System.currentTimeMillis() - startTime))
             tmp.delete()
         } as Runnable)
     }

--- a/core/src/main/groovy/com/muwire/core/files/UIPersistFilesEvent.groovy
+++ b/core/src/main/groovy/com/muwire/core/files/UIPersistFilesEvent.groovy
@@ -1,6 +1,0 @@
-package com.muwire.core.files
-
-import com.muwire.core.Event
-
-class UIPersistFilesEvent extends Event {
-}

--- a/core/src/main/java/com/muwire/core/SharedFile.java
+++ b/core/src/main/java/com/muwire/core/SharedFile.java
@@ -23,7 +23,8 @@ public class SharedFile {
 
     private final String cachedPath;
     private final long cachedLength;
-    
+
+    private String b64PathHash;
     private final String b64EncodedFileName;
     private final String b64EncodedHashRoot;
     private final List<String> b64EncodedHashList;
@@ -40,7 +41,7 @@ public class SharedFile {
         this.cachedLength = file.length();
         this.b64EncodedFileName = Base64.encode(DataUtil.encodei18nString(file.toString()));
         this.b64EncodedHashRoot = Base64.encode(infoHash.getRoot());
-        
+
         List<String> b64List = new ArrayList<String>();
         byte[] tmp = new byte[32];
         for (int i = 0; i < infoHash.getHashList().length / 32; i++) {
@@ -61,7 +62,10 @@ public class SharedFile {
     }
 
     public String getB64PathHash() throws NoSuchAlgorithmException {
-        return Base64.encode(getPathHash());
+        if(b64PathHash == null){
+            b64PathHash = Base64.encode(getPathHash());
+        }
+        return b64PathHash;
     }
 
     public InfoHash getInfoHash() {

--- a/core/src/main/java/com/muwire/core/SharedFile.java
+++ b/core/src/main/java/com/muwire/core/SharedFile.java
@@ -2,6 +2,8 @@ package com.muwire.core;
 
 import java.io.File;
 import java.io.IOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -50,6 +52,16 @@ public class SharedFile {
 
     public File getFile() {
         return file;
+    }
+
+    public byte[] getPathHash() throws NoSuchAlgorithmException {
+        var digester = MessageDigest.getInstance("SHA-256");
+        digester.update(file.getAbsolutePath().getBytes());
+        return digester.digest();
+    }
+
+    public String getB64PathHash() throws NoSuchAlgorithmException {
+        return Base64.encode(getPathHash());
     }
 
     public InfoHash getInfoHash() {

--- a/gui/griffon-app/controllers/com/muwire/gui/MainFrameController.groovy
+++ b/gui/griffon-app/controllers/com/muwire/gui/MainFrameController.groovy
@@ -3,15 +3,11 @@ package com.muwire.gui
 import griffon.core.GriffonApplication
 import griffon.core.artifact.GriffonController
 import griffon.core.controller.ControllerAction
-import griffon.core.mvc.MVCGroup
-import griffon.core.mvc.MVCGroupConfiguration
 import griffon.inject.MVCMember
 import griffon.metadata.ArtifactProviderFor
-import groovy.json.StringEscapeUtils
 import net.i2p.crypto.DSAEngine
 import net.i2p.data.Base64
 import net.i2p.data.Signature
-import net.i2p.data.SigningPrivateKey
 
 import java.awt.Desktop
 import java.awt.Toolkit
@@ -30,15 +26,11 @@ import com.muwire.core.Persona
 import com.muwire.core.SharedFile
 import com.muwire.core.SplitPattern
 import com.muwire.core.download.Downloader
-import com.muwire.core.download.DownloadStartedEvent
 import com.muwire.core.download.UIDownloadCancelledEvent
-import com.muwire.core.download.UIDownloadEvent
 import com.muwire.core.download.UIDownloadPausedEvent
 import com.muwire.core.download.UIDownloadResumedEvent
 import com.muwire.core.filecert.UICreateCertificateEvent
-import com.muwire.core.files.DirectoryUnsharedEvent
 import com.muwire.core.files.FileUnsharedEvent
-import com.muwire.core.files.UIPersistFilesEvent
 import com.muwire.core.search.QueryEvent
 import com.muwire.core.search.SearchEvent
 import com.muwire.core.trust.RemoteTrustList
@@ -371,7 +363,6 @@ class MainFrameController {
         sf.each {  
             core.eventBus.publish(new FileUnsharedEvent(unsharedFile : it))
         }
-        core.eventBus.publish(new UIPersistFilesEvent())
     }
     
     @ControllerAction


### PR DESCRIPTION
Related to #36 

Using the base64 SHA-256 of the shared file's absolute path, a folder structure of `<muwireHome>/files/<hash[:6]>/<hash[6:>.json`. The cut length of the hash was chosen pretty randomly, I admit, but the goal is reduce the number of json files in one folder and reduce the number of possible folders.

A migration from the `files.json` is also in this PR.

Advantages:

 - json files are updated individually when a file has been hashed
 - reduced write speed
 - basically a hashmap so access is O(1)
 - no extra library needed

Disadvantages:

 - One JSON per file --> increased inode count
 - No hash collision check
 - unwieldy pathnames

Possible improvements:

 - the pathnames are quite long so maybe a different hash algorithm can be chosen
 - cut length was chosen randomly so maybe a clever calculation calculate the optimal length for a good balance between directory count and file count per directory
 - another subdirectory level for less files per directory
