### PR TITLE
Updated current stable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ MuWire is a file publishing and networking tool that protects the identity of it
 
 Users can then use their MuWire identities to publish files, search for files published by others, subscribe to each other’s publications and communicate through chat and messaging. Furthermore, users can establish trust-based relationship with each other where they assign a “trust level” to their contacts. 
 
-The current stable release - 0.8.3 is avaiable for download at https://muwire.com.  The latest plugin build and instructions how to install the plugin are available inside I2P at http://muwire.i2p.  MuWire works on any platform Java works on, including Windows, MacOS, Linux, Rapsberry Pi. 
+The current stable release **`0.8.5`** is avaiable for download at https://muwire.com.  The latest plugin build and instructions how to install the plugin are available inside I2P at http://muwire.i2p.  MuWire works on any platform Java works on, including Windows, MacOS, Linux, Rapsberry Pi. 
 
 You can find technical documentation in the [doc] folder.  Also check out the [Wiki] for various other documentation.
 


### PR DESCRIPTION
Also made the version number a bit more visually striking. Normally one would just quickly glance at the "Releases" section to see the latest version, but this project only has tags. So rather than looking for a "Release #.#.#" commit comment, which may or may not be from the latest release, or digging through the commits history, just keeping the version number prominently displayed in the README is the next best thing for quick reference.